### PR TITLE
Auto-build wheels on CI

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04, windows-latest, macos-latest]
+        os: [windows-latest, macos-latest]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-latest, macos-latest]
+        os: [ubuntu-18.04, windows-latest, macos-latest]
 
     steps:
     - uses: actions/checkout@v2
@@ -24,6 +24,7 @@ jobs:
       with:
         # Only build on CPython
         CIBW_BUILD: "cp36-* cp37-* cp38-* cp39-*"
+        CIBW_ENVIRONMENT_LINUX: "CFLAGS='-fPIC'"
 
     - uses: actions/setup-python@v1
       name: Install Python

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -1,0 +1,81 @@
+name: Build Wheels
+
+# Only run on new tags starting with `v`
+on: [push]
+  # push:
+  #   tags:
+  #     - 'v*'
+
+jobs:
+  build_wheels:
+    name: Build wheel on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-18.04, windows-latest, macos-latest]
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: 'recursive'
+
+    - name: set environment variables
+      uses: allenevans/set-env@v1.1.0
+      with:
+        # Only build on CPython
+        CIBW_BUILD: "cp36-* cp37-* cp38-* cp39-*"
+
+    - uses: actions/setup-python@v1
+      name: Install Python
+      with:
+        python-version: '3.7'
+
+    - name: Install cibuildwheel
+      run: |
+        python -m pip install cibuildwheel==1.4.2
+
+    - name: Install Visual C++ for Python 2.7
+      if: startsWith(matrix.os, 'windows')
+      run: |
+        choco install vcpython27 -f -y
+
+    - name: Build wheel
+      run: |
+        python -m cibuildwheel --output-dir wheelhouse
+
+    - uses: actions/upload-artifact@v2
+      with:
+        path: ./wheelhouse/*.whl
+
+  build_sdist:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-python@v2
+        name: Install Python
+        with:
+          python-version: '3.7'
+
+      - name: Build sdist
+        run: python setup.py sdist
+
+      - uses: actions/upload-artifact@v2
+        with:
+          path: dist/*.tar.gz
+
+  upload_pypi:
+    needs: [build_wheels, build_sdist]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: artifact
+          path: dist
+
+      - uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_PASSWORD }}
+          # To test: repository_url: https://test.pypi.org/legacy/


### PR DESCRIPTION
Closes #1

Update: this works on Mac, Windows, and Ubuntu. I just needed to set `CFLAGS` on Ubuntu. [Here's the working run](https://github.com/kylebarron/deflate/runs/1257305872). With the current settings it builds manylinux, Mac 64-bit and Windows 32 and 64-bit, for Python 3.6 through 3.8.

[artifact.zip](https://github.com/dcwatson/deflate/files/5382651/artifact.1.zip)

~~[Here's the failing Ubuntu log](https://github.com/kylebarron/deflate/runs/1257174377?check_suite_focus=true). Not sure if you can see the logs on my fork, but here's the gist of where it fails:~~

<details>

```
Processing /project
Building wheels for collected packages: deflate
  Building wheel for deflate (setup.py): started
  Building wheel for deflate (setup.py): finished with status 'error'
  ERROR: Command errored out with exit status 1:
   command: /opt/_internal/cpython-3.6.10/bin/python3.6 -u -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-req-build-82qwenf5/setup.py'"'"'; __file__='"'"'/tmp/pip-req-build-82qwenf5/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' bdist_wheel -d /tmp/pip-wheel-mng_qgml
       cwd: /tmp/pip-req-build-82qwenf5/
  Complete output (46 lines):
  running bdist_wheel
  running build
  running build_ext
    CC       lib/deflate_decompress.o
    CC       lib/utils.o
    CC       lib/arm/cpu_features.o
    CC       lib/x86/cpu_features.o
    CC       lib/deflate_compress.o
    CC       lib/adler32.o
    CC       lib/zlib_decompress.o
    CC       lib/zlib_compress.o
    CC       lib/crc32.o
    CC       lib/gzip_decompress.o
    CC       lib/gzip_compress.o
    AR       libdeflate.a
    CC       lib/deflate_decompress.shlib.o
    CC       lib/utils.shlib.o
    CC       lib/arm/cpu_features.shlib.o
    CC       lib/x86/cpu_features.shlib.o
    CC       lib/deflate_compress.shlib.o
    CC       lib/adler32.shlib.o
    CC       lib/zlib_decompress.shlib.o
    CC       lib/zlib_compress.shlib.o
    CC       lib/crc32.shlib.o
    CC       lib/gzip_decompress.shlib.o
    CC       lib/gzip_compress.shlib.o
    CCLD     libdeflate.so.0
    LN       libdeflate.so
    GEN      programs/config.h
    CC       programs/gzip.o
    CC       programs/prog_util.o
    CC       programs/tgetopt.o
    CCLD     gzip
    LN       gunzip
  building 'deflate' extension
  creating build
  creating build/temp.linux-x86_64-3.6
  gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -I/opt/_internal/cpython-3.6.10/include/python3.6m -c deflate.c -o build/temp.linux-x86_64-3.6/deflate.o
  creating build/lib.linux-x86_64-3.6
  gcc -pthread -shared build/temp.linux-x86_64-3.6/deflate.o libdeflate/libdeflate.a -o build/lib.linux-x86_64-3.6/deflate.cpython-36m-x86_64-linux-gnu.so
  /opt/rh/devtoolset-8/root/usr/libexec/gcc/x86_64-redhat-linux/8/ld: libdeflate/libdeflate.a(deflate_decompress.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
  /opt/rh/devtoolset-8/root/usr/libexec/gcc/x86_64-redhat-linux/8/ld: libdeflate/libdeflate.a(deflate_compress.o): relocation R_X86_64_32S against `.rodata' can not be used when making a shared object; recompile with -fPIC
  /opt/rh/devtoolset-8/root/usr/libexec/gcc/x86_64-redhat-linux/8/ld: libdeflate/libdeflate.a(crc32.o): relocation R_X86_64_32S against `.rodata' can not be used when making a shared object; recompile with -fPIC
  /opt/rh/devtoolset-8/root/usr/libexec/gcc/x86_64-redhat-linux/8/ld: final link failed: Nonrepresentable section on output
  collect2: error: ld returned 1 exit status
  error: command 'gcc' failed with exit status 1
  ----------------------------------------
  ERROR: Failed building wheel for deflate
  Running setup.py clean for deflate
Failed to build deflate
ERROR: Failed to build one or more wheels
WARNING: You are using pip version 20.1.1; however, version 20.2.3 is available.
You should consider upgrading via the '/opt/_internal/cpython-3.6.10/bin/python3.6 -m pip install --upgrade pip' command.
Checking for common errors...
+ docker rm --force -v cibuildwheel-af1fbc9c-4ee7-49fe-93ad-d7e455bef547
cibuildwheel-af1fbc9c-4ee7-49fe-93ad-d7e455bef547
```

</details>