### PR TITLE
fix(setup.py): compile when using Anaconda

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open(os.path.join(BASE_DIR, "README.md"), "r") as readme:
 class DeflateBuilder(build_ext):
     def run(self, *args, **kwargs):
         libdeflate_dir = os.path.join(BASE_DIR, "libdeflate")
-        result = subprocess.run(["make"], cwd=libdeflate_dir)
+        result = subprocess.run(["make"], cwd=libdeflate_dir, env={ "CFLAGS": "-fPIC" })
         if result.returncode == 0:
             super().run(*args, **kwargs)
         else:


### PR DESCRIPTION
Anaconda adds another compilation step against the statically
compiled library libdeflate.a and dies because libdeflate.a
was not compiled with position independent code. This adds
an environment variable tweak that ensures -fPIC is added to
the compilation of libdeflate.a.

Resolves #4 