### PR TITLE
Use system installed deflate library

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,8 @@ jobs:
         env:
           CIBW_TEST_REQUIRES: pytest pytest-benchmark
           CIBW_TEST_COMMAND: "pytest {project}/tests"
+          # Disable building PyPy wheels on all platforms
+          CIBW_SKIP: pp*
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,9 @@ jobs:
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.3.1
+        env:
+          CIBW_TEST_REQUIRES: pytest pytest-benchmark
+          CIBW_TEST_COMMAND: "pytest {project}/tests"
 
       - uses: actions/upload-artifact@v2
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 * add DeflateError object to module, fixes related ImportError (#14)
 * add deflate.crc32 api, docs, tests (#11)
 * update bundled code to libdeflate v1.10 (#22)
+* prefer system libdeflate (via pkgconfig) over bundled code, see the docs
+  about how to influence this behaviour via environment variables (#29)
 * setup.py: add pypi metadata, require python >= 3.6
 * benchmark deflate.crc32 against zlib.crc32 using pytest-benchmark
 * add tests (using pytest), flake8 linter, CI via github actions (#16, #13)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-deflate
-=======
+deflate API
+===========
 
 This is a very thin Python wrapper Eric Biggers' excellent
 [libdeflate](https://github.com/ebiggers/libdeflate).
@@ -21,4 +21,20 @@ crc32 computation
 import deflate
 crc32 = deflate.crc32(b"hello world! ")  # initial
 crc32 = deflate.crc32(b"hello universe!", crc32)  # continued
+```
+
+deflate package installation
+============================
+
+deflate will:
+- use libdeflate from LIBDEFLATE_PREFIX when given
+- use pkgconfig pypi package (if available) to locate a libdeflate
+- fall back to bundled libdeflate code otherwise or when enforced via 
+  USE_BUNDLED_DEFLATE=yes. 
+
+```
+export USE_BUNDLED_DEFLATE=no  # default is no
+export LIBDEFLATE_PREFIX=/path/to/lib/deflate  # default: no path given
+pip install pkgconfig  # optional, you also need pkg-config cli tool
+pip install deflate
 ```


### PR DESCRIPTION
Use pkgconfig if available to locate a libdeflate system library.

If a specific library prefix is given by LIBDEFLATE_PREFIX=somepath, use that.
Otherwise if pkgconfig is installed and the library can be located via that, use that one.
Otherwise (or if enforced by USE_BUNDLED_DEFLATE=yes), fall back to bundled code.

Build tested, with and without deflate library installed, on OpenBSD
amd64 current. Tests pass.