### PR TITLE
ci: use dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
The actions in the repo are really out of date and spewing warnings about Node.js 16 being deprecated. This will auto-bump all the actions (in one grouped PR) at most monthly (also can be triggered from GitHub's UI, though in a rather unintuitive place).
