### PR TITLE
chore: use ruff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,14 +19,12 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.x"
-      - name: Install Checkers
-        run: pip install flake8 black isort
-      - name: flake8
-        run: flake8 tests
-      - name: black
-        run: black --check tests
-      - name: isort
-        run: isort --check tests
+      - name: Install Ruff
+        run: pip install ruff
+      - name: Checks
+        run: ruff check
+      - name: Format
+        run: ruff format
 
   test:
     needs: checks

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,8 @@ clean:
 
 format:
 	clang-format -i deflate.c
-	black tests
-	isort tests
+	ruff check
+	ruff format
 
 test: clean
 	pip install -e .[test]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,3 +45,13 @@ minimum-version = "0.9"
 provider = "scikit_build_core.metadata.regex"
 input = "deflate.c"
 regex = '.*#define MODULE_VERSION "(?P<value>.*)"'
+
+[tool.ruff]
+extend-exclude = [
+  "libdeflate",
+]
+lint.extend-select = [
+  "B",        # flake8-bugbear
+  "I",        # isort
+]
+lint.isort.known-first-party = ["deflate"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,0 @@
-[flake8]
-max_line_length = 88
-exclude = libdeflate,build,dist,.git,.idea,.cache
-
-[isort]
-profile = black


### PR DESCRIPTION
This gets rid of the `setup.cfg` file by using ruff, which can replace black, flake8, and isort (along with a lot of other things), and is faster. See https://learn.scientific-python.org/development/guides/style/#ruff.
