### PR TITLE
feat: Stable ABI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,9 +22,6 @@ jobs:
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.17.0
-        env:
-          # Disable building PyPy wheels.
-          CIBW_SKIP: pp*
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,8 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest"]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        allow-prereleases: true
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,6 @@ jobs:
       matrix:
         os: ["ubuntu-latest"]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
-        allow-prereleases: true
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -33,6 +32,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
       - name: Install
         run: |
           pip install -r requirements-dev.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 * Switched to [scikit-build-core](https://github.com/scikit-build/scikit-build-core) and
   CMake (#42, #43) - huge thanks to @henryiii
+* Use only [stable Python API](https://docs.python.org/3/c-api/stable.html)
+    * _Note that this can't actually be enabled until Python 3.11 is the minimum
+      supported version._
+* Return [bytearray](https://docs.python.org/3/library/stdtypes.html#bytearray) from
+  compression and decompression methods, to avoid copying (resizing bytes is not stable)
 * Raise `ValueError` instead of `DeflateError` on invalid gzip data
 * Lots of internal refactoring
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
+
+## WIP
+* Use only the [limited Python API](https://docs.python.org/3/c-api/stable.html)
+  * Use the Stable ABI for Python 3.11+
+
 ## 0.7.0 (2024-05-09)
 
 * Switched to [scikit-build-core](https://github.com/scikit-build/scikit-build-core) and
   CMake (#42, #43) - huge thanks to @henryiii
-* Use only [stable Python API](https://docs.python.org/3/c-api/stable.html)
-    * _Note that this can't actually be enabled until Python 3.11 is the minimum
-      supported version._
 * Return [bytearray](https://docs.python.org/3/library/stdtypes.html#bytearray) from
   compression and decompression methods, to avoid copying (resizing bytes is not stable)
 * Raise `ValueError` instead of `DeflateError` on invalid gzip data

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ find_package(Python REQUIRED COMPONENTS Interpreter Development.Module ${SKBUILD
 if(Python_VERSION VERSION_GREATER_EQUAL 3.11)
   python_add_library(deflate_ext MODULE USE_SABI 3.11 src/deflate.c)
 else()
-  python_add_library(deflate_ext MODULE src/deflate.c)
+  python_add_library(deflate_ext MODULE WITH_SOABI src/deflate.c)
 endif()
 set_property(TARGET deflate_ext PROPERTY OUTPUT_NAME deflate)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,14 @@
-cmake_minimum_required(VERSION 3.18...3.29)
+cmake_minimum_required(VERSION 3.26...3.29)
 project(${SKBUILD_PROJECT_NAME} LANGUAGES C)
 
-find_package(Python REQUIRED COMPONENTS Interpreter Development.Module)
+find_package(Python REQUIRED COMPONENTS Interpreter Development.Module ${SKBUILD_SABI_COMPONENT})
 
-python_add_library(deflate_ext MODULE src/deflate.c)
-set_property(TARGET deflate_ext PROPERTY OUTPUT_NAME deflate)
 if(Python_VERSION VERSION_GREATER_EQUAL 3.11)
-  target_compile_definitions(deflate_ext PRIVATE Py_LIMITED_API=0x030b00f0)
+  python_add_library(deflate_ext MODULE USE_SABI 3.11 src/deflate.c)
+else()
+  python_add_library(deflate_ext MODULE src/deflate.c)
 endif()
+set_property(TARGET deflate_ext PROPERTY OUTPUT_NAME deflate)
 
 if(DEFINED ENV{LIBDEFLATE_PREFIX})
     message(STATUS "Finding libdeflate in $ENV{LIBDEFLATE_PREFIX}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,9 @@ find_package(Python REQUIRED COMPONENTS Interpreter Development.Module)
 
 python_add_library(deflate_ext MODULE src/deflate.c)
 set_property(TARGET deflate_ext PROPERTY OUTPUT_NAME deflate)
+if(Python_VERSION VERSION_GREATER_EQUAL 3.11)
+  target_compile_definitions(deflate_ext PRIVATE Py_LIMITED_API=0x030b00f0)
+endif()
 
 if(DEFINED ENV{LIBDEFLATE_PREFIX})
     message(STATUS "Finding libdeflate in $ENV{LIBDEFLATE_PREFIX}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,9 @@ classifiers = [
 [project.urls]
 Homepage = "https://github.com/dcwatson/deflate"
 
+[project.optional-dependencies]
+test = ["pytest>=7"]
+
 [tool.rye]
 managed = true
 dev-dependencies = [
@@ -55,3 +58,8 @@ extend-exclude = ["libdeflate"]
 [tool.ruff.lint]
 extend-select = ["B", "I"]
 isort.known-first-party = ["deflate"]
+
+[tool.cibuildwheel]
+skip = ["pp*"]  # PyPy not supported
+test-extras = ["test"]
+test-command = "pytest {package}/tests"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,8 +42,7 @@ dev-dependencies = [
 
 [tool.scikit-build]
 minimum-version = "0.9"
-# One day...
-# wheel.py-api = "cp311"
+wheel.py-api = "cp311"
 
 [tool.scikit-build.metadata.version]
 provider = "scikit_build_core.metadata.regex"

--- a/src/deflate.c
+++ b/src/deflate.c
@@ -1,7 +1,6 @@
 #define PY_SSIZE_T_CLEAN
 
 // Can't use this until 3.11, when Py_buffer was stabilized
-// Also _PyBytes_Resize is not public API (although it seems like it should be)
 // #define Py_LIMITED_API 0x030b00f0
 #include <Python.h>
 
@@ -29,14 +28,14 @@ static PyObject *compress(Py_buffer *data, int compression_level,
         libdeflate_alloc_compressor(compression_level);
     size_t bound = (*boundfunc)(compressor, data->len);
 
-    PyObject *bytes = PyBytes_FromStringAndSize(NULL, bound);
+    PyObject *bytes = PyByteArray_FromStringAndSize(NULL, bound);
     if (bytes == NULL) {
         libdeflate_free_compressor(compressor);
         return PyErr_NoMemory();
     }
 
     size_t compressed_size = (*compressfunc)(compressor, data->buf, data->len,
-                                             PyBytes_AsString(bytes), bound);
+                                             PyByteArray_AsString(bytes), bound);
     libdeflate_free_compressor(compressor);
 
     if (compressed_size == 0) {
@@ -46,7 +45,7 @@ static PyObject *compress(Py_buffer *data, int compression_level,
     }
 
     if (compressed_size != bound) {
-        _PyBytes_Resize(&bytes, compressed_size);
+        PyByteArray_Resize(bytes, compressed_size);
     }
 
     return bytes;
@@ -56,19 +55,19 @@ static PyObject *decompress(Py_buffer *data, unsigned int originalsize,
                             DecompressFunc decompressfunc) {
     // Nothing in, nothing out.
     if (originalsize == 0) {
-        return PyBytes_FromStringAndSize(NULL, 0);
+        return PyByteArray_FromStringAndSize(NULL, 0);
     }
 
-    PyObject *output = PyBytes_FromStringAndSize(NULL, originalsize);
+    PyObject *output = PyByteArray_FromStringAndSize(NULL, originalsize);
     if (output == NULL) {
         return PyErr_NoMemory();
     }
 
     size_t decompressed_size;
     struct libdeflate_decompressor *decompressor = libdeflate_alloc_decompressor();
-    enum libdeflate_result result =
-        (*decompressfunc)(decompressor, data->buf, data->len, PyBytes_AsString(output),
-                          originalsize, &decompressed_size);
+    enum libdeflate_result result = (*decompressfunc)(
+        decompressor, data->buf, data->len, PyByteArray_AsString(output), originalsize,
+        &decompressed_size);
     libdeflate_free_decompressor(decompressor);
 
     if (result != LIBDEFLATE_SUCCESS) {
@@ -78,7 +77,7 @@ static PyObject *decompress(Py_buffer *data, unsigned int originalsize,
     }
 
     if (decompressed_size != originalsize) {
-        _PyBytes_Resize(&output, decompressed_size);
+        PyByteArray_Resize(output, decompressed_size);
     }
 
     return output;

--- a/src/deflate.c
+++ b/src/deflate.c
@@ -1,7 +1,6 @@
 #define PY_SSIZE_T_CLEAN
+// If Py_LIMITED_API defined (to 0x030b00f0), will use Stable ABI
 
-// Can't use this until 3.11, when Py_buffer was stabilized
-// #define Py_LIMITED_API 0x030b00f0
 #include <Python.h>
 
 #include "libdeflate.h"


### PR DESCRIPTION
Wheel build here: https://github.com/henryiii/deflate/actions/workflows/build.yml

From logs:

```
Found previously built wheel deflate-0.7.0-cp311-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl, that's compatible with cp312-manylinux_x86_64. Skipping build step...
```

I've enabled running the tests on the built wheels in cibuildwheel, including running the 3.12 tests on the 3.11 Stable ABI wheels. I also added CPython 3.13 to the test matrix (beta 1 was just shipped for GHA yesterday, but it's pulling a6 still for some reason, maybe caching).