### PR TITLE
docs: update install warning and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
     * Use the Stable ABI for Python 3.11+
 * Return [bytearray](https://docs.python.org/3/library/stdtypes.html#bytearray) from compression and decompression methods to avoid copying (resizing bytes is private API)
 * Added typing stubs (and a shell python package to hold them and the renamed `_deflate` compiled extension) (#49)
+* Added support and compiled wheels for PyPy.
 
 
 ## 0.7.0 (2024-05-09)

--- a/README.md
+++ b/README.md
@@ -48,19 +48,24 @@ adler32 = deflate.adler32(b"hello universe!", adler32)  # continued
 
 # Installation
 
-`pip install deflate`
+```bash
+pip install deflate
+```
 
 By default, `deflate` will compile and statically link the bundled `libdeflate` when you
-build from source. To link to a system-installed `libdeflate`, set the
-`LIBDEFLATE_PREFIX` environment variable:
+build from source (or use the pre-compiled wheels). To link to a system-installed `libdeflate`, set the
+`LIBDEFLATE_PREFIX` environment variable and build from source:
 
 ```
-LIBDEFLATE_PREFIX=/opt/homebrew/Cellar/libdeflate/1.20 python -m build
+LIBDEFLATE_PREFIX=/opt/homebrew/Cellar/libdeflate/1.20 pip install deflate --no-binary=deflate
 ```
+
+Be warned: you can't use this wheel on a system without the referenced libdeflate.
 
 # Testing
 
-```
+```bash
 pip install -r requirements-dev.lock
 python -m pytest
 ```
+


### PR DESCRIPTION
Some small suggested updates. 

FYI, you can pass CMake defined using `-Ccmake.define.SOME_VAR=...` in pip and build if you'd like a non-envvar way to pass this.
