### PR TITLE
fix: make sure SOABI present

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,10 +3,10 @@ project(${SKBUILD_PROJECT_NAME} LANGUAGES C)
 
 find_package(Python REQUIRED COMPONENTS Interpreter Development.Module ${SKBUILD_SABI_COMPONENT})
 
-if(Python_VERSION VERSION_GREATER_EQUAL 3.11 AND Python_INTERPRETER_ID STREQUAL Python)
-    python_add_library(_deflate MODULE USE_SABI 3.11 src/_deflate.c)
-else()
+if("${SKBUILD_SABI_COMPONENT}" STREQUAL "")
     python_add_library(_deflate MODULE WITH_SOABI src/_deflate.c)
+else()
+    python_add_library(_deflate MODULE WITH_SOABI USE_SABI 3.11 src/_deflate.c)
 endif()
 
 if(DEFINED ENV{LIBDEFLATE_PREFIX})


### PR DESCRIPTION
Realized this was not ideal - it’s not implied (even though the docs make it seem like it is).

Also using skbuild’s logic for including this to be ready for free-threading builds of Python 3.13.