### PR TITLE
fix: ensure proper CMake version present

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ dev-dependencies = [
 [tool.scikit-build]
 minimum-version = "0.9"
 wheel.py-api = "cp311"
+cmake.version = ">=3.26"
 
 [tool.scikit-build.metadata.version]
 provider = "scikit_build_core.metadata.regex"


### PR DESCRIPTION
This should match your `cmake_minimum_version`.

(By the way, does threading make any sense? I could update this for free-threaded Python quite easily if it does).